### PR TITLE
Publish cache as prerelease

### DIFF
--- a/.github/workflows/build-sample-project.yml
+++ b/.github/workflows/build-sample-project.yml
@@ -46,3 +46,17 @@ jobs:
         run: npx esy build --release
       - name: Bundle JS app
         run: npm run bundle
+      - name: Create a Release
+        uses: elgohr/Github-Release-Action@v5
+        if: github.ref_name == 'main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        with:
+          title: dev-${{ github.sha }}
+      - name: Upload to release
+        uses: softprops/action-gh-release@v1
+        if: github.ref_name == 'main'
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+          prerelease: true
+          files: ./_export


### PR DESCRIPTION
Action artifacts are short lived. Release artifacts aren't.